### PR TITLE
if response has not "{" character, code was crashed.

### DIFF
--- a/SocketIO.m
+++ b/SocketIO.m
@@ -1009,7 +1009,8 @@ NSString* const SocketIOException = @"SocketIOException";
         DEBUGLOG(@"VERSION 10x");
         _version = V10x;
         //...0{"sid":"<sid>","upgrades":[<transports>,...],"pingInterval":<timeHeartbeat>,"pingTimeout":<timeOut>}
-        responseString = [responseString substringFromIndex:[responseString rangeOfString:@"{"].location];
+        if([responseString rangeOfString:@"{"].location != NSNotFound)
+            responseString = [responseString substringFromIndex:[responseString rangeOfString:@"{"].location];
         DEBUGLOG(@"Response %@", responseString);
         connectionFailed = true;
         NSData *utf8Data = [responseString dataUsingEncoding:NSUTF8StringEncoding];


### PR DESCRIPTION
on my test server while testing, Server start to return;
`<html><head><title>Not found</title></head><body>Not found</body></html>`

and my application began to crash. Eventually we have to check this character before using substringFromIndex method.
