### PR TITLE
Add path support

### DIFF
--- a/SocketIO.h
+++ b/SocketIO.h
@@ -101,6 +101,7 @@ typedef enum {
 @property (nonatomic, readonly) NSString *sid;
 @property (nonatomic, readonly) NSTimeInterval heartbeatTimeout;
 @property (nonatomic) BOOL useSecure;
+@property (nonatomic) NSString *path;
 @property (nonatomic) NSArray *cookies;
 @property (nonatomic, readonly) BOOL isConnected, isConnecting;
 @property (nonatomic, weak) id<SocketIODelegate> delegate;

--- a/SocketIO.m
+++ b/SocketIO.m
@@ -36,11 +36,11 @@
 #define DEBUGLOG(...)
 #endif
 
-static NSString* kResourceName = @"socket.io";
+static NSString* kResourceName = @"/socket.io";
 static NSString* kTransportPolling = @"polling";
 static NSString* kTransportWebsocket = @"websocket";
-static NSString* kHandshakeURL = @"%@://%@%@/%@/1/?EIO=2&transport=%@&t=%.0f%@";
-static NSString* kForceDisconnectURL = @"%@://%@%@/%@/1/xhr-polling/%@?disconnect";
+static NSString* kHandshakeURL = @"%@://%@%@%@%@/1/?EIO=2&transport=%@&t=%.0f%@";
+static NSString* kForceDisconnectURL = @"%@://%@%@%@%@/1/xhr-polling/%@?disconnect";
 
 float const defaultConnectionTimeout = 10.0f;
 
@@ -137,7 +137,7 @@ NSString* const SocketIOException = @"SocketIOException";
         NSString *protocol = _useSecure ? @"https" : @"http";
         NSString *port = _port ? [NSString stringWithFormat:@":%d", _port] : @"";
         NSTimeInterval time = [[NSDate date] timeIntervalSince1970] * 1000;
-        NSString *handshakeUrl = [NSString stringWithFormat:kHandshakeURL, protocol, _host, port, kResourceName,kTransportPolling, time, query];
+        NSString *handshakeUrl = [NSString stringWithFormat:kHandshakeURL, protocol, _host, port, _path, kResourceName,kTransportPolling, time, query];
         //@"%@://%@%@/%@/1/?t=%.0f%@";
         //http://<host><port>/socket.io/1/?t=<time>f<query>
         
@@ -186,7 +186,7 @@ NSString* const SocketIOException = @"SocketIOException";
 {
     NSString *protocol = [self useSecure] ? @"https" : @"http";
     NSString *port = _port ? [NSString stringWithFormat:@":%d", _port] : @"";
-    NSString *urlString = [NSString stringWithFormat:kForceDisconnectURL, protocol, _host, port, kResourceName, _sid];
+    NSString *urlString = [NSString stringWithFormat:kForceDisconnectURL, protocol, _host, port, _path, kResourceName, _sid];
     NSURL *url = [NSURL URLWithString:urlString];
     DEBUGLOG(@"Force disconnect at: %@", urlString);
     

--- a/SocketIO.m
+++ b/SocketIO.m
@@ -91,6 +91,7 @@ NSString* const SocketIOException = @"SocketIOException";
         _ackCount = 0;
         _acks = [[NSMutableDictionary alloc] init];
         _returnAllDataFromAck = NO;
+        _path=@"";
     }
     return self;
 }

--- a/SocketIOTransport.h
+++ b/SocketIOTransport.h
@@ -38,6 +38,7 @@ typedef enum SocketIOVersion
 @property (nonatomic, readonly) NSString *sid;
 @property (nonatomic, readonly) NSTimeInterval heartbeatTimeout;
 @property (nonatomic) BOOL useSecure;
+@property (nonatomic) NSString *path;
 
 @end
 

--- a/SocketIOTransportWebsocket.m
+++ b/SocketIOTransportWebsocket.m
@@ -29,10 +29,10 @@
 #define DEBUGLOG(...)
 #endif
 
-static NSString* kInsecureSocketURL = @"ws://%@/socket.io/1/websocket/%@%@";
-static NSString* kSecureSocketURL = @"wss://%@/socket.io/1/websocket/%@%@";
-static NSString* kInsecureSocketPortURL = @"ws://%@:%d/socket.io/1/websocket/%@%@";
-static NSString* kSecureSocketPortURL = @"wss://%@:%d/socket.io/1/websocket/%@%@";
+static NSString* kInsecureSocketURL = @"ws://%@%@/socket.io/1/websocket/%@%@";
+static NSString* kSecureSocketURL = @"wss://%@%@/socket.io/1/websocket/%@%@";
+static NSString* kInsecureSocketPortURL = @"ws://%@:%d%@/socket.io/1/websocket/%@%@";
+static NSString* kSecureSocketPortURL = @"wss://%@:%d%@/socket.io/1/websocket/%@%@";
 
 @implementation SocketIOTransportWebsocket
 
@@ -68,11 +68,11 @@ static NSString* kSecureSocketPortURL = @"wss://%@:%d/socket.io/1/websocket/%@%@
     
     if (delegate.port) {
         format = delegate.useSecure ? kSecureSocketPortURL : kInsecureSocketPortURL;
-        urlStr = [NSString stringWithFormat:format, delegate.host, delegate.port, addOnVersion, delegate.sid];
+        urlStr = [NSString stringWithFormat:format, delegate.host, delegate.port, delegate.path, addOnVersion, delegate.sid];
     }
     else {
         format = delegate.useSecure ? kSecureSocketURL : kInsecureSocketURL;
-        urlStr = [NSString stringWithFormat:format, delegate.host,addOnVersion, delegate.sid];
+        urlStr = [NSString stringWithFormat:format, delegate.host, delegate.path, addOnVersion, delegate.sid];
     }
     NSURL *url = [NSURL URLWithString:urlStr];
     

--- a/SocketIOTransportXHR.m
+++ b/SocketIOTransportXHR.m
@@ -29,10 +29,10 @@
 #define DEBUGLOG(...)
 #endif
 
-static NSString* kInsecureXHRURL = @"http://%@/socket.io/1/xhr-polling/%@";
-static NSString* kSecureXHRURL = @"https://%@/socket.io/1/xhr-polling/%@";
-static NSString* kInsecureXHRPortURL = @"http://%@:%d/socket.io/1/xhr-polling/%@";
-static NSString* kSecureXHRPortURL = @"https://%@:%d/socket.io/1/xhr-polling/%@";
+static NSString* kInsecureXHRURL = @"http://%@%@/socket.io/1/xhr-polling/%@";
+static NSString* kSecureXHRURL = @"https://%@%@/socket.io/1/xhr-polling/%@";
+static NSString* kInsecureXHRPortURL = @"http://%@:%d%@/socket.io/1/xhr-polling/%@";
+static NSString* kSecureXHRPortURL = @"https://%@:%d%@/socket.io/1/xhr-polling/%@";
 
 @interface SocketIOTransportXHR (Private)
 - (void) checkAndStartPoll;
@@ -67,11 +67,11 @@ static NSString* kSecureXHRPortURL = @"https://%@:%d/socket.io/1/xhr-polling/%@"
     NSString *format;
     if (delegate.port) {
         format = delegate.useSecure ? kSecureXHRPortURL : kInsecureXHRPortURL;
-        _url = [NSString stringWithFormat:format, delegate.host, delegate.port, delegate.sid];
+        _url = [NSString stringWithFormat:format, delegate.host, delegate.port, delegate.path, delegate.sid];
     }
     else {
         format = delegate.useSecure ? kSecureXHRURL : kInsecureXHRURL;
-        _url = [NSString stringWithFormat:format, delegate.host, delegate.sid];
+        _url = [NSString stringWithFormat:format, delegate.host, delegate.path, delegate.sid];
     }
     DEBUGLOG(@"Opening XHR @ %@", _url);
     [self poll:nil];


### PR DESCRIPTION
I only tested this on socket.io v1.0, but looks like should also work with v0.9 (where used to be called a resource). I auto-synthesized the property - hope that's okay. I tested without a path and also with a path (going through nginx reverse proxy) and seems to work fine.  